### PR TITLE
list comprehensions are slower than generators to iterate through.

### DIFF
--- a/week01/theory/3_statements.ipynb
+++ b/week01/theory/3_statements.ipynb
@@ -591,7 +591,7 @@
     "You may be wondering, if the generator expression can't be reused more than once, why would anyone use this instead of a normal list?\n",
     "\n",
     "The answer is memory and time!\n",
-    "Generators don't construct a list object, so instead of storing the whole list in memory, they generate one item at a time and generate the next only when in demand. On the other hand, in a list comprehension, memory is reserved for the whole list. Additionally, generators are also more time efficient than list comprehensions."
+    "Generators don't construct a list object, so instead of storing the whole list in memory, they generate one item at a time and generate the next only when in demand. On the other hand, in a list comprehension, memory is reserved for the whole list. Generators are more time efficient than list comprehensions to create, however, lists are more time efficient to iterate through."
    ]
   },
   {
@@ -1123,7 +1123,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
try running the following code to see this in action :D

'''
# generators are not more memory efficient than list comprehensions

import timeit
import time
import random

# create a random list
list = [random.random() for i in range(100000)]

# use a list comprehension to create list_gallons
listime1 = time.time()
list_gallons = [round(item * 0.2641720524, 4) for item in list]
listime2 = time.time()
print("time to make list: ", listime2 - listime1)

# create a generator instead of a list by substituting brackets with parenthesis
gentime1 = time.time()
generator_gallons = (round(item * 0.2641720524, 4) for item in list)
gentime2 = time.time()
print("time to make generator: ", gentime2 - gentime1)

# iterator using a list
def list_iter():
    for item in list_gallons:
        continue

# iterator using a generator
def generator_iter():
    for item in generator_gallons:
        continue

print("time to iterator through list: ", timeit.timeit(list_iter, number=1))
print("time to iterator through generator: ", timeit.timeit(generator_iter, number=1))
'''